### PR TITLE
Do not call setState if the component has already been unmounted

### DIFF
--- a/src/components/AsyncButton.js
+++ b/src/components/AsyncButton.js
@@ -9,6 +9,10 @@ export default class AsyncButton extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.isUnmounted = true
+  }
+
   resetState() {
     this.setState({
       asyncState: null,
@@ -25,10 +29,16 @@ export default class AsyncButton extends React.Component {
       const returnFn = clickHandler(args)
       if (returnFn && typeof returnFn.then === 'function') {
         returnFn.then(() => {
+          if (this.isUnmounted) {
+            return
+          }
           this.setState({
             asyncState: 'fulfilled',
           })
         }).catch((error) => {
+          if (this.isUnmounted) {
+            return
+          }
           this.setState({
             asyncState: 'rejected',
           })

--- a/src/components/__tests__/AsyncButton-test.js
+++ b/src/components/__tests__/AsyncButton-test.js
@@ -1,7 +1,7 @@
 /* global describe, it, expect */
 import React from 'react'
 import AsyncButton from '../AsyncButton.js'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import sinon from 'sinon'
 
 describe('main.js', () => {
@@ -27,5 +27,20 @@ describe('main.js', () => {
     const $button = wrapper.find('button')
     $button.simulate('click')
     expect(clickHandler.calledOnce).toBe(true)
+  })
+
+  it('should not call setState after unmount', () => {
+    let resolve
+    const promise = new Promise((_resolve) => { resolve = _resolve })
+    let onClick = () => promise
+    const wrapper = mount(<AsyncButton onClick={onClick} />)
+    wrapper.find('button').simulate('click')
+    wrapper.unmount()
+    wrapper.node.setState = sinon.spy()
+
+    resolve()
+    return Promise.resolve().then(() => {
+      expect(wrapper.node.setState.callCount).toBe(0);
+    })
   })
 })


### PR DESCRIPTION
I have a component that navigates away from the page immediately after a successful async action. As a result I was seeing the following warning in the console:  `"Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the AsyncButton component."`.

This pr changes it so `setState` is never called asynchronously if the component was unmounted before the promise resolves or rejects.



